### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
Potential fix for [https://github.com/priyanshujain/infragpt/security/code-scanning/1](https://github.com/priyanshujain/infragpt/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it requires `contents: write` to push changes to the repository. Adding this block at the root level of the workflow ensures that all jobs inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
