### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/priyanshujain/infragpt/security/code-scanning/4](https://github.com/priyanshujain/infragpt/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic CI tasks, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to repository contents and no write permissions.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This avoids redundancy and ensures consistency across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
