### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/priyanshujain/infragpt/security/code-scanning/2](https://github.com/priyanshujain/infragpt/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and does not require write access, we can set `contents: read` as the minimal permission. This ensures the `GITHUB_TOKEN` is restricted to only the necessary scope.

The `permissions` block should be added at the root level of the workflow, applying to all jobs. This is the most efficient approach since the workflow does not have multiple jobs requiring different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
