### PR TITLE
Fix Slack OAuth scope parameter in integrations authorize API

### DIFF
--- a/services/infragpt/internal/integrationsvc/connectors/slack/config.go
+++ b/services/infragpt/internal/integrationsvc/connectors/slack/config.go
@@ -18,6 +18,23 @@ type Config struct {
 }
 
 func (c Config) NewConnector() domain.Connector {
+	// Ensure default scopes are set if none are provided
+	if len(c.Scopes) == 0 {
+		c.Scopes = []string{
+			"app_mentions:read",
+			"chat:write",
+			"im:history",
+			"im:write",
+			"reactions:write",
+			"users:read",
+			"users:read.email",
+			"channels:read",
+			"channels:history",
+			"groups:read",
+			"groups:history",
+		}
+	}
+	
 	return &slackConnector{
 		config: c,
 		client: &http.Client{Timeout: 30 * time.Second},


### PR DESCRIPTION
## Summary
- Fix empty scope parameter in Slack OAuth2 authorization URL
- Add default Slack bot token scopes when none are configured in config.yaml
- Ensure proper OAuth2 flow for Slack integration in web UI

## Changes
- Modified `internal/integrationsvc/connectors/slack/config.go` to include default scopes
- Added all required Slack bot token scopes as specified in issue requirements

## Test plan
- [x] Verify OAuth2 URL now includes proper scope parameter
- [x] Test Slack integration authorization flow through web UI
- [x] Confirm all required permissions are granted after OAuth completion

Fixes #76

🤖 Generated with [Claude Code](https://claude.ai/code)