### PR TITLE
Replace third-party Netlify action with direct CLI usage

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -33,10 +33,12 @@ jobs:
         working-directory: services/website
         run: npm run build
         
+      - name: Install Netlify CLI
+        run: npm install -g netlify-cli
+        
       - name: Deploy to Netlify
-        uses: netlify/actions/cli@master
-        with:
-          args: deploy --dir=services/website/dist --prod
+        working-directory: services/website
+        run: netlify deploy --dir=dist --prod --message "Deploy from GitHub Actions"
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Replaces the unmaintained third-party Netlify action with direct CLI usage to eliminate deprecated warnings and improve reliability.

## Problem Resolved
- **Deprecated warnings**: The `netlify/actions/cli@master` action uses deprecated `::set-output` commands
- **Maintenance concerns**: Third-party action may not be actively maintained
- **External dependency**: Reduces reliance on external GitHub Actions

## Changes Made
- ✅ **Remove third-party action**: Replaced `netlify/actions/cli@master` 
- ✅ **Install CLI directly**: Added `npm install -g netlify-cli` step
- ✅ **Direct CLI usage**: Use `netlify deploy` command directly
- ✅ **Add deploy message**: Better tracking with `--message` flag
- ✅ **Maintain functionality**: Same deployment behavior with improved reliability

## Updated Workflow Steps
```yaml
- name: Install Netlify CLI
  run: npm install -g netlify-cli
  
- name: Deploy to Netlify
  working-directory: services/website
  run: netlify deploy --dir=dist --prod --message "Deploy from GitHub Actions"
  env:
    NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
    NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
```

## Benefits
- ✅ No more deprecated GitHub Actions warnings
- ✅ Direct control over Netlify CLI version
- ✅ Reduced external dependencies
- ✅ More maintainable and debuggable
- ✅ Same deployment functionality

## Test Plan
- [ ] Verify workflow runs without deprecated warnings
- [ ] Confirm successful deployment to Netlify
- [ ] Validate deployment message appears in Netlify logs

## Closes
Resolves #84

🤖 Generated with [Claude Code](https://claude.ai/code)