### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/services/app/src/services/integrationService.ts
+++ b/services/app/src/services/integrationService.ts
@@ -307,7 +307,7 @@ export const withErrorHandling = async <T>(
     const sanitizedContext = errorContext 
       ? errorContext.replace(/[\r\n\t]/g, ' ').substring(0, 100)
       : '';
-    console.error('Integration service error' + (sanitizedContext ? ` (${sanitizedContext})` : '') + ':', error);
+    console.error('Integration service error%s:', sanitizedContext ? ` (${sanitizedContext})` : '', error);
     throw error;
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/priyanshujain/infragpt/security/code-scanning/6](https://github.com/priyanshujain/infragpt/security/code-scanning/6)

To fix the issue, the untrusted input (`errorContext`) should be passed as a separate argument to the `console.error` function using a `%s` specifier in the format string. This ensures that the input is treated as a literal string and prevents any format string injection vulnerabilities.

**Steps to fix:**
1. Modify the `console.error` call in the `withErrorHandling` function to use a `%s` specifier in the format string.
2. Pass the sanitized `errorContext` as a separate argument to `console.error`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
