### PR TITLE
Strengthen the types

### DIFF
--- a/cli/src/infragpt/bump_version.py
+++ b/cli/src/infragpt/bump_version.py
@@ -6,7 +6,8 @@ import subprocess
 from pathlib import Path
 
 
-def get_current_version():
+def get_current_version() -> str:
+    """Get the current version from __init__.py."""
     init_file = Path("src/infragpt/__init__.py")
     if not init_file.exists():
         raise FileNotFoundError(f"Could not find {init_file}")
@@ -21,8 +22,8 @@ def get_current_version():
     return match.group(1)
 
 
-def update_version(new_version):
-    # Update version in __init__.py
+def update_version(new_version: str) -> None:
+    """Update version in __init__.py and pyproject.toml."""
     init_file = Path("src/infragpt/__init__.py")
     with open(init_file, "r") as f:
         content = f.read()
@@ -49,8 +50,8 @@ def update_version(new_version):
     print(f"Updated version to {new_version}")
 
 
-def commit_and_tag(version):
-    # Commit changes
+def commit_and_tag(version: str) -> None:
+    """Commit version bump and create a git tag."""
     subprocess.run(
         ["git", "add", "src/infragpt/__init__.py", "pyproject.toml"], check=True
     )
@@ -67,7 +68,8 @@ def commit_and_tag(version):
     print(f"  git push origin master && git push origin {tag_name}")
 
 
-def bump_version(part="patch"):
+def bump_version(part: str = "patch") -> str:
+    """Calculate the new version based on the bump type."""
     current = get_current_version()
     major, minor, patch = map(int, current.split("."))
 
@@ -83,7 +85,8 @@ def bump_version(part="patch"):
     return new_version
 
 
-def main():
+def main() -> None:
+    """Main entry point for the version bump CLI."""
     parser = argparse.ArgumentParser(description="Bump InfraGPT version")
     parser.add_argument(
         "part",

--- a/cli/src/infragpt/config.py
+++ b/cli/src/infragpt/config.py
@@ -3,6 +3,7 @@
 import os
 import yaml
 import pathlib
+from typing import Any, Dict
 
 from rich.console import Console
 
@@ -21,7 +22,7 @@ CONFIG_DIR = pathlib.Path.home() / ".config" / "infragpt"
 CONFIG_FILE = CONFIG_DIR / "config.yaml"
 
 
-def load_config():
+def load_config() -> Dict[str, Any]:
     """Load configuration from config file."""
     if not CONFIG_FILE.exists():
         return {}
@@ -34,7 +35,7 @@ def load_config():
         return {}
 
 
-def save_config(config):
+def save_config(config: Dict[str, Any]) -> None:
     """Save configuration to config file."""
     # Ensure directory exists
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -46,7 +47,7 @@ def save_config(config):
         console.print(f"[yellow]Warning:[/yellow] Could not save config: {e}")
 
 
-def init_config():
+def init_config() -> None:
     """Initialize configuration file with environment variables if it doesn't exist."""
     if CONFIG_FILE.exists():
         return

--- a/cli/src/infragpt/main.py
+++ b/cli/src/infragpt/main.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 from rich.panel import Panel
@@ -68,7 +68,7 @@ def get_credentials_v2(
     model_string: Optional[str] = None,
     api_key: Optional[str] = None,
     verbose: bool = False,
-):
+) -> Tuple[str, str]:
     """Get credentials for the new system."""
     # If model is provided, validate it
     if model_string:
@@ -129,7 +129,9 @@ def get_credentials_v2(
     return model_string, api_key
 
 
-def main(model, api_key, verbose):
+def main(
+    model: Optional[str], api_key: Optional[str], verbose: bool
+) -> None:
     """InfraGPT V2 - Interactive shell operations with direct SDK integration."""
     # Initialize config file if it doesn't exist
     init_config()

--- a/cli/src/infragpt/shell.py
+++ b/cli/src/infragpt/shell.py
@@ -163,7 +163,7 @@ class CommandExecutor(ExecutorInterface):
 
         return "".join(output_lines)
 
-    def _timeout_handler(self):
+    def _timeout_handler(self) -> None:
         """Handle command timeout."""
         if self.current_process and self.current_process.poll() is None:
             console.print(
@@ -171,7 +171,7 @@ class CommandExecutor(ExecutorInterface):
             )
             self._terminate_command()
 
-    def _terminate_command(self):
+    def _terminate_command(self) -> None:
         """Terminate the current command."""
         if self.current_process:
             try:
@@ -186,7 +186,7 @@ class CommandExecutor(ExecutorInterface):
             except (OSError, ProcessLookupError):
                 pass
 
-    def _esc_listener(self):
+    def _esc_listener(self) -> None:
         """Listen for ESC key to cancel command."""
         try:
             import termios
@@ -212,7 +212,7 @@ class CommandExecutor(ExecutorInterface):
         except Exception:
             pass
 
-    def update_environment(self, env_vars: Dict[str, str]):
+    def update_environment(self, env_vars: Dict[str, str]) -> None:
         """Update environment variables for future commands."""
         self.env.update(env_vars)
 

--- a/cli/src/infragpt/tools.py
+++ b/cli/src/infragpt/tools.py
@@ -46,7 +46,9 @@ def cleanup_executor() -> None:
         _host_executor = None
 
 
-def tool(name: Optional[str] = None, description: Optional[str] = None):
+def tool(
+    name: Optional[str] = None, description: Optional[str] = None
+) -> Callable[[Callable], Callable]:
     """
     Decorator to convert a function into a tool definition.
     Replacement for LangChain's @tool decorator.
@@ -115,7 +117,7 @@ def tool(name: Optional[str] = None, description: Optional[str] = None):
         func._tool = tool_obj
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             return func(*args, **kwargs)
 
         return wrapper

--- a/services/agent/src/agents/base.py
+++ b/services/agent/src/agents/base.py
@@ -2,11 +2,14 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 import logging
 
 from src.models.agent import AgentResponse
 from src.models.context import AgentContext
+
+if TYPE_CHECKING:
+    from src.llm import LiteLLMClient
 
 
 class AgentType(Enum):
@@ -25,7 +28,7 @@ class BaseAgent(ABC):
         self.logger = logging.getLogger(f"{__name__}.{agent_type.value}")
 
         # LLM client will be injected during initialization
-        self.llm_client: Optional[object] = None
+        self.llm_client: Optional["LiteLLMClient"] = None
 
         self.logger.info(f"Initialized {agent_type.value} agent")
 
@@ -60,7 +63,7 @@ class BaseAgent(ABC):
         """
         pass
 
-    def set_llm_client(self, llm_client: object) -> None:
+    def set_llm_client(self, llm_client: "LiteLLMClient") -> None:
         """Set the LLM client for this agent."""
         self.llm_client = llm_client
         self.logger.debug(f"Set LLM client for {self.name} agent")

--- a/services/agent/src/agents/main_agent.py
+++ b/services/agent/src/agents/main_agent.py
@@ -119,7 +119,7 @@ class MainAgent(BaseAgent):
             tools_used=[],
         )
 
-    def set_llm_client(self, llm_client: object) -> None:
+    def set_llm_client(self, llm_client: LiteLLMClient) -> None:
         """Set LLM client for all agents."""
         super().set_llm_client(llm_client)
 

--- a/services/agent/src/agents/registry.py
+++ b/services/agent/src/agents/registry.py
@@ -1,7 +1,7 @@
 """Agent registry and factory for managing agent instances."""
 
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from src.agents.main_agent import MainAgent
 from src.models.agent import AgentRequest, AgentResponse
@@ -86,7 +86,7 @@ class AgentSystem:
             metadata={"context": request.context},
         )
 
-    def set_llm_client(self, llm_client: object) -> None:
+    def set_llm_client(self, llm_client: LiteLLMClient) -> None:
         """Set LLM client for the agent system."""
         if self.main_agent:
             self.main_agent.set_llm_client(llm_client)
@@ -98,7 +98,7 @@ class AgentSystem:
         """Check if the agent system is ready to process requests."""
         return self._initialized and self.main_agent is not None
 
-    def get_system_status(self) -> dict:
+    def get_system_status(self) -> Dict[str, Any]:
         """Get status of the entire agent system."""
         if not self._initialized:
             return {"status": "not_initialized"}


### PR DESCRIPTION
- Replace `object` type with `LiteLLMClient` for llm_client in agent service (base.py, main_agent.py, registry.py)
- Add return type annotations to CLI modules (bump_version.py, config.py, main.py, shell.py, tools.py)
- Add parameter type annotations where missing
- Replace untyped `dict` with `Dict[str, Any]` in registry.py
- Add TYPE_CHECKING import for proper type hints without circular imports